### PR TITLE
Added a message when the script finished backing up

### DIFF
--- a/src/zmbkpose
+++ b/src/zmbkpose
@@ -1286,6 +1286,7 @@ case $action in
 				debug "Waiting $time_btw_bks secs..." && sleep $time_btw_bks
 		done
 		wait #Waiting for background processes
+		debug "Backup FINISHED $bk_count backups performed"
     ;;
 
 	(GET_BACKUPS_INFO|GET_FIRST_BACKUP_INFO|GET_LAST_BACKUP_INFO) #Get info from backups 


### PR DESCRIPTION
There is no message to say the backup has completed successfully. This patch prints a message when the full backup has finished.
