### PR TITLE
Fix for bug #65

### DIFF
--- a/src/zmbkpose
+++ b/src/zmbkpose
@@ -783,6 +783,7 @@ rotate_backup ()
 ###### MAIN ############
 # Here the code loads the config file
 source /etc/zmbkpose/zmbkpose.conf
+source /opt/zimbra/.bashrc
 
 if ! [ -z "$BACKUPUSER" ]; then
 	if [ "$(id -u)" != "$(id -u $BACKUPUSER)" ]; then


### PR DESCRIPTION
Just a change to make the Zmbkpose load the user's zimbra $PATH before doing anything. This correct the error where the ldapsearch is not found when you execute de script via crontab.
